### PR TITLE
[stable/yugaware] Remove 'release' keys from configMap

### DIFF
--- a/stable/yugaware/templates/service.yaml
+++ b/stable/yugaware/templates/service.yaml
@@ -62,14 +62,12 @@ spec:
         - name: yugaware-config
           configMap:
             name: {{ .Release.Name }}-yugaware-app-config
-            release: {{ .Release.Name }}
             items:
               - key: application.docker.conf
                 path: application.docker.conf
         - name: nginx-config
           configMap:
             name: {{ .Release.Name }}-yugaware-nginx-config
-            release: {{ .Release.Name }}
             items:
               - key: default.conf
                 path: default.conf


### PR DESCRIPTION
[closes YugaByte/yugabyte-db#1398] remove 'release' keys from configMap.

No rush, I know these are a lot of probably annoying questions at once / maybe there aren't 100% clear answers yet:

- Not sure if/how you all would prefer PRs? 
- Should it be against this repo?
- Against "master" or a "develop" branch?
- Would you like PRs also to bump the Chart version from 1.2.8 to 1.2.9?

Like I said, no worries or rush. Not trying to throw off your sprints or focuses 👍 just stuff to think about