### PR TITLE
Helm chart update to autorun initdb when YSQL is not disabled

### DIFF
--- a/stable/yugabyte/Chart.yaml
+++ b/stable/yugabyte/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: yugabyte
-version: 1.2.11
-appVersion: 1.2.11.0-b9
+version: 1.2.10
+appVersion: 1.2.10.0-b13
 home: https://www.yugabyte.com
 description: YugaByte Database is the high-performance distributed SQL database for building global, internet-scale applications 
 icon: https://avatars0.githubusercontent.com/u/17074854?s=200&v=4

--- a/stable/yugabyte/Chart.yaml
+++ b/stable/yugabyte/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: yugabyte
-version: 1.2.8  
-appVersion: 1.2.8.0-b1 
+version: 1.2.11
+appVersion: 1.2.11.0-b9
 home: https://www.yugabyte.com
 description: YugaByte Database is the high-performance distributed SQL database for building global, internet-scale applications 
 icon: https://avatars0.githubusercontent.com/u/17074854?s=200&v=4

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -221,6 +221,9 @@ spec:
           - "--master_addresses={{ template "yugabyte.master_addresses" $root }}"
           - "--replication_factor={{ $root.Values.replicas.master }}"
           {{ end }}
+          {{ if not $root.Values.disableYsql }}
+          - "--master_auto_run_initdb=true"
+          {{ end }}
           - "--metric_node_name=$(HOSTNAME)"
           - "--memory_limit_hard_bytes={{ template "yugabyte.memory_hard_limit" $root.Values.resource.master }}"
           - "--stderrthreshold=0"

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -56,7 +56,7 @@ gflags:
 PodManagementPolicy: Parallel
 
 # Flag to use to disable YugaByte SQL support on tservers.
-# disableYsql: true
+disableYsql: true
 
 enableLoadBalancer: True
 

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -4,7 +4,7 @@
 Component: "yugabytedb"
 Image:
   repository: "yugabytedb/yugabyte"
-  tag: 1.2.11.0-b9
+  tag: 1.2.10.0-b13
   pullPolicy: IfNotPresent
 
 storage:
@@ -56,7 +56,7 @@ gflags:
 PodManagementPolicy: Parallel
 
 # Flag to use to disable YugaByte SQL support on tservers.
-disableYsql: true
+disableYsql: True
 
 enableLoadBalancer: True
 

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -4,7 +4,7 @@
 Component: "yugabytedb"
 Image:
   repository: "yugabytedb/yugabyte"
-  tag: 1.2.8.0-b1 
+  tag: 1.2.11.0-b9
   pullPolicy: IfNotPresent
 
 storage:


### PR DESCRIPTION
#### What this PR does / why we need it: Runs initdb on universe creation to enable YSQL on Yugabyte.