### PR TITLE
Change PSQL bind address to use Pod IP

### DIFF
--- a/stable/yugabyte/Chart.yaml
+++ b/stable/yugabyte/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: yugabyte
-version: 1.2.10
-appVersion: 1.2.10.0-b13
+version: 1.2.11
+appVersion: 1.2.11.0-b12
 home: https://www.yugabyte.com
 description: YugaByte Database is the high-performance distributed SQL database for building global, internet-scale applications 
 icon: https://avatars0.githubusercontent.com/u/17074854?s=200&v=4
@@ -11,4 +11,4 @@ maintainers:
 - name: Ram Sri 
   email: ram@yugabyte.com 
 - name: Arnav Agarwal 
-  email: Agarwl13@illinois.edu
+  email: arnav@yugabyte.com

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -243,7 +243,7 @@ spec:
           - "--cql_proxy_bind_address={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}"
           {{ if not $root.Values.disableYsql }}
           - "--start_pgsql_proxy"
-          - "--pgsql_proxy_bind_address={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}:5433"
+          - "--pgsql_proxy_bind_address={{ printf "$(POD_IP)" }}:5433"
           {{ end }}
           {{ if $root.Values.isMultiAz }}
           - "--tserver_master_addrs={{ $root.Values.masterAddresses}}"


### PR DESCRIPTION
Since PSQL has a 64 character limit for the bind address, changing it to use the Pod IP helps us circumvent that issue. Since the bind address will be refreshed every time the pod restarts, the DNS should always resolve to the current Pod IP.
Tested this by creating a YSQL enabled universe and checked if we could connect to PSQL. Also verified the connection works when the pod dies and comes up with a new IP.
`kubectl exec -it yb-tserver-1 -n abcdefghijklmnopqrstuvwxyzabcdefghijklmnop -- ./bin/psql -h yb-tserver-0.yb-tservers.abcdefghijklmnopqrstuvwxyzabcdefghijklmnop.svc.cluster.local -U postgres`