### PR TITLE
Modified conf to support custom timeout

### DIFF
--- a/stable/yugaware/Chart.yaml
+++ b/stable/yugaware/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.2.13.0-b8
+appVersion: 1.2.13.0-b10
 version: 1.2.13
 home: https://www.yugabyte.com
 description: YugaWare is YugaByte Database's Orchestration and Management console.

--- a/stable/yugaware/Chart.yaml
+++ b/stable/yugaware/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 1.2.8.0-b1
-version: 1.2.8
+appVersion: 1.2.13.0-b8
+version: 1.2.13
 home: https://www.yugabyte.com
 description: YugaWare is YugaByte Database's Orchestration and Management console.
 name: yugaware

--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -57,8 +57,8 @@ data:
       docker.release = "/opt/yugabyte/release"
       # TODO(bogdan): need this extra level for installing from local...
       thirdparty.packagePath = /opt/third-party/third-party
-      helm.package = "/opt/yugabyte/helm/yugabyte-latest.tgz"
-      helm.timeout_secs = 900
+      helm.package = "{{ .Values.helm.package }}"
+      helm.timeout_secs = {{ .Values.helm.timeout }}
       health.check_interval_ms = 300000
       health.status_interval_ms = 43200000
       health.default_email = "alerts@yugabyte.com"

--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -58,6 +58,7 @@ data:
       # TODO(bogdan): need this extra level for installing from local...
       thirdparty.packagePath = /opt/third-party/third-party
       helm.package = "/opt/yugabyte/helm/yugabyte-latest.tgz"
+      helm.timeout_secs = 900
       health.check_interval_ms = 300000
       health.status_interval_ms = 43200000
       health.default_email = "alerts@yugabyte.com"

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -21,3 +21,7 @@ yugaware:
   health:
     username: ""
     password: ""
+
+helm:
+  timeout: 900
+  package: "/opt/yugabyte/helm/yugabyte-latest.tgz"

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: quay.io/yugabyte/yugaware
-  tag: 1.2.13.0-b8  
+  tag: 1.2.13.0-b10
   pullPolicy: IfNotPresent
   pullSecret: yugabyte-k8s-pull-secret
 

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: quay.io/yugabyte/yugaware
-  tag: 1.2.8.0-b1  
+  tag: 1.2.13.0-b8  
   pullPolicy: IfNotPresent
   pullSecret: yugabyte-k8s-pull-secret
 


### PR DESCRIPTION
#### What this PR does / why we need it: Provides the ability to customize helm timeouts to ensure that helm doesn't fail faster than expected.