### PR TITLE
[stable/chart/yugaware] Fix docker config and bump version

### DIFF
--- a/stable/yugaware/Chart.yaml
+++ b/stable/yugaware/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 1.3.0.0-b1
-version: 1.3.0
+appVersion: 1.3.1.0-b16
+version: 1.3.1
 home: https://www.yugabyte.com
 description: YugaWare is YugaByte Database's Orchestration and Management console.
 name: yugaware

--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -30,6 +30,9 @@ data:
     play.crypto.secret=${APP_SECRET}
     play.i18n.langs = [ "en" ]
     pidfile.path = "/dev/null"
+    play.evolutions.enabled=false
+    play.modules.enabled += "org.flywaydb.play.PlayModule"
+
     db {
       default.url="jdbc:postgresql://127.0.0.1:5432/"${POSTGRES_DB}
       default.driver=org.postgresql.Driver


### PR DESCRIPTION
Fixed the docker conf to make it work after recent changes on YugaByte packaging (169ee076)
New YB packaging bundles FlyWayDB migration scripts and Ebean Evolution scripts. But evolution script is only needed for a standalone YugaByte. This fix, basically ignores the evolution scripts and just rely on FlyWayDB migration scripts.

Signed-off-by: Ram Sri <ram@yugabyte.com>

Fixes https://github.com/YugaByte/yugabyte-db/issues/1955


