### PR TITLE
Added templatized value assignment to health check emails

### DIFF
--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -64,7 +64,7 @@ data:
       helm.timeout_secs = {{ .Values.helm.timeout }}
       health.check_interval_ms = 300000
       health.status_interval_ms = 43200000
-      health.default_email = "alerts@yugabyte.com"
+      health.default_email = "{{ .Values.yugaware.health.email }}"
       health.ses_email_username = "{{ .Values.yugaware.health.username }}"
       health.ses_email_password = "{{ .Values.yugaware.health.password }}"
     }

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -21,6 +21,7 @@ yugaware:
   health:
     username: ""
     password: ""
+    email: ""
 
 helm:
   timeout: 900


### PR DESCRIPTION
Since we have moved to open source, we should use templates for assigning the alerting email value rather than hardcoding it. 