### PR TITLE
[stable/yugaware] Add annotation option for YugaWare

### DIFF
--- a/stable/yugaware/Chart.yaml
+++ b/stable/yugaware/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 1.3.1.0-b16
-version: 1.3.1
+appVersion: 1.3.2.0-b18
+version: 1.3.2
 home: https://www.yugabyte.com
 description: YugaWare is YugaByte Database's Orchestration and Management console.
 name: yugaware

--- a/stable/yugaware/templates/service.yaml
+++ b/stable/yugaware/templates/service.yaml
@@ -11,6 +11,10 @@ metadata:
     chart: {{ template "yugaware.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.yugaware.service.annotations }}
+    annotations:
+{{ toYaml .Values.yugaware.service.annotations | indent 6 }}
+    {{- end }}
 spec:
   clusterIP:
   ports:


### PR DESCRIPTION
Give an override option to provider annotation for YugaWare service.

Tested by creating a overrides.yaml as below
```
yugaware:
  service:
    annotations:
        service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
        service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
```
and then run
```
helm install yugaware --name demo --values=overrides.yaml --debug --dry-run
```

https://github.com/YugaByte/yugabyte-db/issues/1338
