### PR TITLE
Pin container versions in YW service.yaml

### DIFF
--- a/stable/yugabyte/Chart.yaml
+++ b/stable/yugabyte/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: yugabyte
-version: 2.0.0
-appVersion: 2.0.0.0-b16
+version: 2.0.1
+appVersion: 2.0.1.0-b19
 home: https://www.yugabyte.com
 description: YugaByte Database is the high-performance distributed SQL database for building global, internet-scale applications 
 icon: https://avatars0.githubusercontent.com/u/17074854?s=200&v=4

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -4,7 +4,7 @@
 Component: "yugabytedb"
 Image:
   repository: "yugabytedb/yugabyte"
-  tag: 2.0.0.0-b16 
+  tag: 2.0.1.0-b19 
   pullPolicy: IfNotPresent
 
 storage:

--- a/stable/yugaware/Chart.yaml
+++ b/stable/yugaware/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 2.0.0.0-b16
-version: 2.0.0
+appVersion: 2.0.1.0-b19
+version: 2.0.1
 home: https://www.yugabyte.com
 description: YugaWare is YugaByte Database's Orchestration and Management console.
 name: yugaware

--- a/stable/yugaware/templates/service.yaml
+++ b/stable/yugaware/templates/service.yaml
@@ -66,14 +66,12 @@ spec:
         - name: yugaware-config
           configMap:
             name: {{ .Release.Name }}-yugaware-app-config
-            release: {{ .Release.Name }}
             items:
               - key: application.docker.conf
                 path: application.docker.conf
         - name: nginx-config
           configMap:
             name: {{ .Release.Name }}-yugaware-nginx-config
-            release: {{ .Release.Name }}
             items:
               - key: default.conf
                 path: default.conf
@@ -84,7 +82,7 @@ spec:
               - key: prometheus.yml
                 path: prometheus.yml
       containers:
-        - image: postgres
+        - image: postgres:11.5
           name: postgres
           env:
             - name: POSTGRES_USER
@@ -185,7 +183,7 @@ spec:
             mountPath: /opt/swamper_targets/
             subPath: swamper_targets
         - name: nginx
-          image: nginx:latest
+          image: nginx:1.14.7
           ports:
           - containerPort: 80
           volumeMounts:

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: quay.io/yugabyte/yugaware
-  tag: 2.0.0.0-b16 
+  tag: 2.0.1.0-b19 
   pullPolicy: IfNotPresent
   pullSecret: yugabyte-k8s-pull-secret
 


### PR DESCRIPTION
Since prometheus has breaking changes from 11 to 12, we need to explicitly pin the version of the container's image. This is also in general a better practice to avoid incompatible changes in the future.