### PR TITLE
[stable/yugaware] Fix nginx version tag

### DIFF
--- a/stable/yugaware/templates/service.yaml
+++ b/stable/yugaware/templates/service.yaml
@@ -183,7 +183,7 @@ spec:
             mountPath: /opt/swamper_targets/
             subPath: swamper_targets
         - name: nginx
-          image: nginx:1.14.7
+          image: nginx:1.17.4
           ports:
           - containerPort: 80
           volumeMounts:


### PR DESCRIPTION
Pinning nginx to the latest tag version as of 10/16/2019.