### PR TITLE
Fix rbac to support create operations

### DIFF
--- a/stable/yugabyte/Chart.yaml
+++ b/stable/yugabyte/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: yugabyte
-version: 2.0.1
-appVersion: 2.0.1.0-b19
+version: 2.0.2
+appVersion: 2.0.2.0-b10
 home: https://www.yugabyte.com
 description: YugaByte Database is the high-performance distributed SQL database for building global, internet-scale applications 
 icon: https://avatars0.githubusercontent.com/u/17074854?s=200&v=4

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -4,7 +4,7 @@
 Component: "yugabytedb"
 Image:
   repository: "yugabytedb/yugabyte"
-  tag: 2.0.1.0-b19 
+  tag: 2.0.2.0-b10
   pullPolicy: IfNotPresent
 
 storage:

--- a/stable/yugaware/Chart.yaml
+++ b/stable/yugaware/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 2.0.1.0-b19
-version: 2.0.1
+appVersion: 2.0.2.0-b10
+version: 2.0.2
 home: https://www.yugabyte.com
 description: YugaWare is YugaByte Database's Orchestration and Management console.
 name: yugaware

--- a/stable/yugaware/templates/rbac.yaml
+++ b/stable/yugaware/templates/rbac.yaml
@@ -24,7 +24,7 @@ rules:
   - endpoints
   - pods
   - pods/exec
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "create"]
 - apiGroups:
   - extensions
   resources:

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: quay.io/yugabyte/yugaware
-  tag: 2.0.1.0-b19 
+  tag: 2.0.2.0-b10 
   pullPolicy: IfNotPresent
   pullSecret: yugabyte-k8s-pull-secret
 


### PR DESCRIPTION
Yugaware pods did not have create access for operations on the cluster which caused cp commands to fail. Adding the ability to perform create operations from the YW pod as well as bumping the version to 2.0.2.
Tested by creating an encryption enabled universe and checked that the copy step completed and the universe came up as expected.