### PR TITLE
[stable/yugabyte] Add busybox sidecar, postStart hook and an initContainer to Yugabyte deployments.

### DIFF
--- a/stable/yugabyte/Chart.yaml
+++ b/stable/yugabyte/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: yugabyte
-version: 2.0.2
-appVersion: 2.0.2.0-b10
+version: 2.0.4
+appVersion: 2.0.4.0-b7
 home: https://www.yugabyte.com
 description: YugaByte Database is the high-performance distributed SQL database for building global, internet-scale applications 
 icon: https://avatars0.githubusercontent.com/u/17074854?s=200&v=4

--- a/stable/yugabyte/app-readme.md
+++ b/stable/yugabyte/app-readme.md
@@ -1,1 +1,1 @@
-This chart bootstraps an RF3 Yugabyte DB version 2.0.2.0-b10 cluster using the Helm Package Manager.
+This chart bootstraps an RF3 Yugabyte DB version 2.0.4.0-b7 cluster using the Helm Package Manager.

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -203,7 +203,9 @@ spec:
                 - >
                   mkdir -p /mnt/disk0/cores;
                   mkdir -p /mnt/disk0/yb-data/scripts;
-                  cp /home/yugabyte/bin/log_cleanup.sh /mnt/disk0/yb-data/scripts;
+                  if [ -f /home/yugabyte/bin/log_cleanup.sh ]; then
+                    cp /home/yugabyte/bin/log_cleanup.sh /mnt/disk0/yb-data/scripts;
+                  fi
         env:
         - name: POD_IP
           valueFrom:

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -203,6 +203,7 @@ spec:
                 - >
                   mkdir -p /mnt/disk0/cores;
                   mkdir -p /mnt/disk0/yb-data/scripts;
+                  cp /home/yugabyte/bin/log_cleanup.sh /mnt/disk0/yb-data/scripts;
         env:
         - name: POD_IP
           valueFrom:
@@ -304,11 +305,11 @@ spec:
           - >
             mkdir /var/spool/cron;
             mkdir /var/spool/cron/crontabs;
-            export USER="yugabyte"
+            export USER="yugabyte";
             echo "* * * * * /home/scripts/log_cleanup.sh" | tee -a /var/spool/cron/crontabs/root;
             crond;
             while true; do
-              sleep 3000;
+              sleep 86400;
             done
         volumeMounts:
           - name: datadir0

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -276,6 +276,19 @@ spec:
             readOnly: true
           {{- end }}
 
+      - name: yb-cleanup
+        image: busybox
+        command:
+          - "/bin/sh"
+          - "-c"
+          - >
+            while true; do
+              sleep 3000;
+            done
+        volumeMounts:
+          - name: datadir0
+            mountPath: /home
+            subPath: yb-data
 
       volumes:
         {{- range $index := until (int ($storageInfo.count)) }}

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -282,6 +282,10 @@ spec:
           - "/bin/sh"
           - "-c"
           - >
+            mkdir /var/spool/cron;
+            mkdir /var/spool/cron/crontabs;
+            echo "* * * * * /home/scripts/log_cleanup.sh" | tee -a /var/spool/cron/crontabs/root;
+            crond;
             while true; do
               sleep 3000;
             done

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -179,10 +179,30 @@ spec:
                   values:
                   - "{{ .label }}"
               topologyKey: kubernetes.io/hostname
+      initContainers:
+        - name: init-sysctl
+          image: busybox
+          command:
+          - /bin/sh
+          - -c
+          - |
+            sysctl -w vm.swappiness=0
+            sysctl -w kernel.core_pattern="/home/yugabyte/cores/core_%e.%p"
+          securityContext:
+            privileged: true
       containers:
       - name: "{{ .label }}"
         image: "{{ $root.Values.Image.repository }}:{{ $root.Values.Image.tag }}"
         imagePullPolicy: {{ $root.Values.Image.pullPolicy }}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - "sh"
+                - "-c"
+                - >
+                  mkdir -p /mnt/disk0/cores;
+                  mkdir -p /mnt/disk0/yb-data/scripts;
         env:
         - name: POD_IP
           valueFrom:
@@ -277,13 +297,14 @@ spec:
           {{- end }}
 
       - name: yb-cleanup
-        image: busybox
+        image: busybox:1.31
         command:
           - "/bin/sh"
           - "-c"
           - >
             mkdir /var/spool/cron;
             mkdir /var/spool/cron/crontabs;
+            export USER="yugabyte"
             echo "* * * * * /home/scripts/log_cleanup.sh" | tee -a /var/spool/cron/crontabs/root;
             crond;
             while true; do

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -301,13 +301,15 @@ spec:
 
       - name: yb-cleanup
         image: busybox:1.31
+        env:
+        - name: USER
+          value: "yugabyte"
         command:
           - "/bin/sh"
           - "-c"
           - >
             mkdir /var/spool/cron;
             mkdir /var/spool/cron/crontabs;
-            export USER="yugabyte";
             echo "0 0 * * * /home/yugabyte/scripts/log_cleanup.sh" | tee -a /var/spool/cron/crontabs/root;
             crond;
             while true; do

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -308,14 +308,14 @@ spec:
             mkdir /var/spool/cron;
             mkdir /var/spool/cron/crontabs;
             export USER="yugabyte";
-            echo "* * * * * /home/scripts/log_cleanup.sh" | tee -a /var/spool/cron/crontabs/root;
+            echo "0 0 * * * /home/yugabyte/scripts/log_cleanup.sh" | tee -a /var/spool/cron/crontabs/root;
             crond;
             while true; do
               sleep 86400;
             done
         volumeMounts:
           - name: datadir0
-            mountPath: /home
+            mountPath: /home/yugabyte/
             subPath: yb-data
 
       volumes:

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -4,7 +4,7 @@
 Component: "yugabytedb"
 Image:
   repository: "yugabytedb/yugabyte"
-  tag: 2.0.2.0-b10
+  tag: 2.0.4.0-b7
   pullPolicy: IfNotPresent
 
 storage:

--- a/stable/yugaware/Chart.yaml
+++ b/stable/yugaware/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 2.0.2.0-b10
-version: 2.0.2
+appVersion: 2.0.4.0-b7
+version: 2.0.4
 home: https://www.yugabyte.com
 description: YugaWare is YugaByte Database's Orchestration and Management console.
 name: yugaware

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: quay.io/yugabyte/yugaware
-  tag: 2.0.2.0-b10 
+  tag: 2.0.4.0-b7
   pullPolicy: IfNotPresent
   pullSecret: yugabyte-k8s-pull-secret
 


### PR DESCRIPTION
This PR takes care of the following changes:
1) Closes issue (https://github.com/yugabyte/yugabyte-db/issues/1487). 
2) Set sysctl values.
3) Correctly link the core files.

Tested by creating a custom YB container image with the log cleanup script packaged and verified that the pods come up with the sidecar and the sidecar has the cronjob running to clean up the logs. Verified the script itself by creating placeholder logs and verifying that they get cleared with every run.
Tested that the core files are symlinked correctly and that the directory exists.