### PR TITLE
[3144] Fix generate kubeconfig to support python3

### DIFF
--- a/stable/yugabyte/generate_kubeconfig.py
+++ b/stable/yugabyte/generate_kubeconfig.py
@@ -21,7 +21,7 @@ def run_command(command_args, namespace=None, as_json=True):
         command.extend(['-o', 'json'])
         return json.loads(check_output(command))
     else:
-        return check_output(command)
+        return check_output(command).decode('utf8')
 
 
 parser = argparse.ArgumentParser(description='Generate KubeConfig with Token')


### PR DESCRIPTION
Added string decode option to support python3, tested by running

`python3  stable/yugabyte/generate_kubeconfig.py `

also test python2
`python  stable/yugabyte/generate_kubeconfig.py`