### PR TITLE
[stable/yugabyte][stable/yugaware] Remove disableYsql default and bump version.

### DIFF
--- a/stable/yugabyte/Chart.yaml
+++ b/stable/yugabyte/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: yugabyte
-version: 2.0.5
-appVersion: 2.0.5.2-b3
+version: 2.0.9
+appVersion: 2.0.9.0-b13
 home: https://www.yugabyte.com
 description: YugaByte Database is the high-performance distributed SQL database for building global, internet-scale applications 
 icon: https://avatars0.githubusercontent.com/u/17074854?s=200&v=4

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -4,7 +4,7 @@
 Component: "yugabytedb"
 Image:
   repository: "yugabytedb/yugabyte"
-  tag: 2.0.5.2-b3
+  tag: 2.0.9.0-b13
   pullPolicy: IfNotPresent
 
 storage:
@@ -54,9 +54,6 @@ gflags:
     use_cassandra_authentication: False
 
 PodManagementPolicy: Parallel
-
-# Flag to use to disable YugaByte SQL support on tservers.
-disableYsql: True
 
 enableLoadBalancer: True
 

--- a/stable/yugaware/Chart.yaml
+++ b/stable/yugaware/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 2.0.5.2-b3
-version: 2.0.5
+appVersion: 2.0.9.0-b13
+version: 2.0.9
 home: https://www.yugabyte.com
 description: YugaWare is YugaByte Database's Orchestration and Management console.
 name: yugaware

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: quay.io/yugabyte/yugaware
-  tag: 2.0.5.2-b3
+  tag: 2.0.9.0-b13
   pullPolicy: IfNotPresent
   pullSecret: yugabyte-k8s-pull-secret
 


### PR DESCRIPTION
#### What this PR does / why we need it: 
Removes the disableYsql default in yugabyte so that yugabyte clusters come up with YSQL enabled by default.

#### Which issue this PR fixes
  - fixes https://github.com/yugabyte/yugabyte-db/issues/3306

#### Checklist
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
