### PR TITLE
[stable/yugabyte][stable/yugaware] Fixed YW chart to use PV for prometheus data storage.

### DIFF
--- a/stable/yugabyte/Chart.yaml
+++ b/stable/yugabyte/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: yugabyte
-version: 2.0.9
-appVersion: 2.0.9.0-b13
+version: 2.0.11
+appVersion: 2.0.11.0-b23
 home: https://www.yugabyte.com
 description: YugaByte Database is the high-performance distributed SQL database for building global, internet-scale applications 
 icon: https://avatars0.githubusercontent.com/u/17074854?s=200&v=4

--- a/stable/yugabyte/app-readme.md
+++ b/stable/yugabyte/app-readme.md
@@ -1,1 +1,1 @@
-This chart bootstraps an RF3 Yugabyte DB version 2.0.5.2-b3 cluster using the Helm Package Manager.
+This chart bootstraps an RF3 Yugabyte DB version 2.0.11.0-b23 cluster using the Helm Package Manager.

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -4,7 +4,7 @@
 Component: "yugabytedb"
 Image:
   repository: "yugabytedb/yugabyte"
-  tag: 2.0.9.0-b13
+  tag: 2.0.11.0-b23
   pullPolicy: IfNotPresent
 
 storage:

--- a/stable/yugaware/Chart.yaml
+++ b/stable/yugaware/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 2.0.9.0-b13
-version: 2.0.9
+appVersion: 2.0.11.0-b23
+version: 2.0.11
 home: https://www.yugabyte.com
 description: YugaWare is YugaByte Database's Orchestration and Management console.
 name: yugaware

--- a/stable/yugaware/templates/service.yaml
+++ b/stable/yugaware/templates/service.yaml
@@ -61,8 +61,6 @@ spec:
           emptyDir: {}
         - name: thirdparty-deps
           emptyDir: {}
-        - name: prometheus-storage
-          emptyDir: {}
         - name: yugaware-config
           configMap:
             name: {{ .Release.Name }}-yugaware-app-config
@@ -111,10 +109,12 @@ spec:
               subPath: postgres_data
         - name: prometheus
           image: prom/prometheus:v2.2.1
+          securityContext:
+            runAsUser: 0
           volumeMounts:
           - name: prometheus-config
             mountPath: /etc/prometheus/
-          - name: prometheus-storage
+          - name: yugaware-storage
             mountPath: /prometheus/
           - name: yugaware-storage
             mountPath: /opt/swamper_targets/

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: quay.io/yugabyte/yugaware
-  tag: 2.0.9.0-b13
+  tag: 2.0.11.0-b23
   pullPolicy: IfNotPresent
   pullSecret: yugabyte-k8s-pull-secret
 


### PR DESCRIPTION
#### What this PR does / why we need it:
YW prometheus utilized a temporary disk to store its data, causing loss of metrics everytime the pod restarted (due to rescheduling, updates or so on). This PR fixes that issue by using the yugaware PVC to store the prometheus data.

Tested it by upgrading from the older helm chart install `helm install yugabytedb/yugaware --name yw-version-test --namespace yw-version-test --wait` to the current one. Also tested upgrading the current chart with a different software version to check that the prometheus data persisted.

#### Which issue this PR fixes
  - fixes https://github.com/yugabyte/yugabyte-db/issues/3356

#### Checklist
- [X ] Chart Version bumped
- [X ] Title of the PR starts with chart name (e.g. `[stable/chart]`)
