### PR TITLE
Revert "Create and use specific service account for pod specs"

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -179,7 +179,6 @@ spec:
                   values:
                   - "{{ .label }}"
               topologyKey: kubernetes.io/hostname
-      serviceAccountName: "{{ $root.Values.serviceAccount.Name }}"
       initContainers:
         - name: init-sysctl
           image: busybox
@@ -344,26 +343,4 @@ spec:
     matchLabels:
       app: {{ .label }}
 {{- end }}
-{{- end }}
-
-{{- if ne $root.Values.serviceAccount.Name "default" }}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ $root.Values.serviceAccount.Name }}
-  namespace: {{ $root.Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ $root.Values.serviceAccount.Name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: {{ $root.Values.serviceAccount.Name }}
-    namespace: {{ $root.Release.Namespace }}
 {{- end }}

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -92,6 +92,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-
-serviceAccount:
-  Name: yugabyte-helm


### PR DESCRIPTION
Reverts yugabyte/charts#47

This breaks because it only works for helm3