### PR TITLE
[stable/yugabyte] Enable tserver service loadbalancer by default

### DIFF
--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -68,6 +68,14 @@ serviceEndpoints:
     ports:
       ui: "7000"
 
+  - name: "yb-tserver-service"
+    type: LoadBalancer
+    app: "yb-tserver"
+    ports:
+      yql-port: "9042"
+      yedis-port: "6379"
+      ysql-port: "5433"
+
 Services:
   - name: "yb-masters"
     label: "yb-master"


### PR DESCRIPTION
#### What this PR does / why we need it:
Defaults creation of loadbalancer for the yb-tserver service exposing the API ports for YSQL, YCQL and YEDIS.
