### PR TITLE
[stable/yugaware] Updated charts to add PDB and resource specification for YW

### DIFF
--- a/stable/yugaware/templates/pdb.yaml
+++ b/stable/yugaware/templates/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-yugaware-pdb
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-yugaware

--- a/stable/yugaware/templates/service.yaml
+++ b/stable/yugaware/templates/service.yaml
@@ -152,6 +152,10 @@ spec:
         - name: yugaware
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{ if .Values.yugaware.resources }}
+          resources:
+{{ toYaml .Values.yugaware.resources | indent 12 }}
+          {{- end }}
           command: [ "/bin/bash", "-c"]
           args:
             - "bin/yugaware -Dconfig.file=/data/application.docker.conf"


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds a pod disruption budget for the YW pod and it adds the ability to specify resource constraints for the YW container.

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
