### PR TITLE
[stable/yugabyte] Add a 'storage.ephemeral' knob.

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -102,8 +102,9 @@ spec:
   {{ else }}
   replicas: {{ $root.Values.replicas.tserver  }}
   {{ end }}
+  {{- $storageInfo := (eq .name "yb-masters") | ternary $root.Values.storage.master $root.Values.storage.tserver -}}
+  {{ if not $root.Values.storage.ephemeral }}
   volumeClaimTemplates:
-    {{- $storageInfo := (eq .name "yb-masters") | ternary $root.Values.storage.master $root.Values.storage.tserver -}}
     {{- range $index := until (int ($storageInfo.count )) }}
     - metadata:
         name: datadir{{ $index }}
@@ -124,6 +125,7 @@ spec:
           requests:
             storage: {{ $storageInfo.size }}
     {{- end }}
+  {{- end }}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -228,7 +230,11 @@ spec:
         command:
         {{ if eq .name "yb-masters" }}
           - "/home/yugabyte/bin/yb-master"
+          {{ if not $root.Values.storage.ephemeral }}
           - "--fs_data_dirs={{ template "yugabyte.fs_data_dirs" $storageInfo }}"
+          {{ else }}
+          - "--fs_data_dirs=/var/yugabyte"
+          {{- end }}
           - "--rpc_bind_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}"
           - "--server_broadcast_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}:7100"
           {{ if $root.Values.isMultiAz }}
@@ -289,9 +295,11 @@ spec:
             name: {{ $label | quote }}
           {{- end}}
         volumeMounts:
+          {{ if not $root.Values.storage.ephemeral }}
           {{- range $index := until (int ($storageInfo.count)) }}
           - name: datadir{{ $index }}
             mountPath: /mnt/disk{{ $index }}
+          {{- end }}
           {{- end }}
           {{- if $root.Values.tls.enabled }}
           - name: {{ .label }}-yugabyte-tls-cert
@@ -299,6 +307,7 @@ spec:
             readOnly: true
           {{- end }}
 
+      {{ if not $root.Values.storage.ephemeral }}
       - name: yb-cleanup
         image: busybox:1.31
         env:
@@ -319,12 +328,15 @@ spec:
           - name: datadir0
             mountPath: /home/yugabyte/
             subPath: yb-data
+      {{- end }}
 
       volumes:
+        {{ if not $root.Values.storage.ephemeral }}
         {{- range $index := until (int ($storageInfo.count)) }}
         - name: datadir{{ $index }}
           hostPath:
             path: /mnt/disks/ssd{{ $index }}
+        {{- end }}
         {{- end }}
         {{- if $root.Values.tls.enabled }}
         - name: {{ .label }}-yugabyte-tls-cert

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -8,6 +8,7 @@ Image:
   pullPolicy: IfNotPresent
 
 storage:
+  ephemeral: false  # will not allocate PVs when true
   master:
     count: 2
     size: 10Gi


### PR DESCRIPTION
#### What this PR does / why we need it:

 Many charts provide a 'persistence.enabled' feature, which is helpful in certain circumstances
such as ephemeral integration tests, where the use case does not warrant persistence but
does value quick startup and a comprehensive cleanup.

This patch adds a related feature under the 'storage' section.  By default, the chart behaves as it
did prior to this patch.  However, setting storage.ephemeral to true allows the pods to deploy
without any dependency on external PVs.

Signed-off-by: Greg Haskins <greg@manetu.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
