### PR TITLE
Append release name to ClusterRoleBinding's name as well

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -403,7 +403,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ $root.Values.serviceAccount.Name }}
+  name: {{ $root.Values.serviceAccount.Name }}-{{ $root.Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
As the ClusterRoleBinding is a cluster scoped resource, it's name needs to be unique. This makes sure that we have separate CRB when installing multiple releases of this chart in same cluster.