### PR TITLE
[stable/yugabyte][stable/yugaware] Update chart to allow migration from helm 2 to helm 3.

### DIFF
--- a/stable/yugabyte/Chart.yaml
+++ b/stable/yugabyte/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: yugabyte
-version: 2.1.4
-appVersion: 2.1.4.0-b5
+version: 2.1.5
+appVersion: 2.1.5.0-b17
 home: https://www.yugabyte.com
 description: YugabyteDB is the high-performance distributed SQL database for building global, internet-scale apps. 
 icon: https://avatars0.githubusercontent.com/u/17074854?s=200&v=4

--- a/stable/yugabyte/Chart.yaml
+++ b/stable/yugabyte/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: yugabyte
-version: 2.1.2
-appVersion: 2.1.2.0-b10
+version: 2.1.4
+appVersion: 2.1.4.0-b5
 home: https://www.yugabyte.com
 description: YugabyteDB is the high-performance distributed SQL database for building global, internet-scale apps. 
 icon: https://avatars0.githubusercontent.com/u/17074854?s=200&v=4

--- a/stable/yugabyte/app-readme.md
+++ b/stable/yugabyte/app-readme.md
@@ -1,1 +1,1 @@
-This chart bootstraps an RF3 Yugabyte DB version 2.1.2.0-b10 cluster using the Helm Package Manager.
+This chart bootstraps an RF3 Yugabyte DB version 2.1.4.0-b5 cluster using the Helm Package Manager.

--- a/stable/yugabyte/app-readme.md
+++ b/stable/yugabyte/app-readme.md
@@ -1,1 +1,1 @@
-This chart bootstraps an RF3 Yugabyte DB version 2.1.4.0-b5 cluster using the Helm Package Manager.
+This chart bootstraps an RF3 Yugabyte DB version 2.1.5.0-b17 cluster using the Helm Package Manager.

--- a/stable/yugabyte/templates/NOTES.txt
+++ b/stable/yugabyte/templates/NOTES.txt
@@ -14,7 +14,10 @@
   kubectl exec --namespace {{ .Release.Namespace }} -it yb-tserver-0 /home/yugabyte/bin/ysqlsh -- -h yb-tserver-0.yb-tservers.{{ .Release.Namespace }}
 
 6. Cleanup YugabyteDB Pods
+  For helm 2:
   helm delete {{ .Release.Name }} --purge
+  For helm 3:
+  helm delete {{ .Release.Name }} -n {{ $root.Release.Namespace }}
   NOTE: You need to manually delete the persistent volume
   {{- $root := . -}}
   {{- range .Values.Services }}

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -203,20 +203,6 @@ spec:
                   values:
                   - "{{ .label }}"
               topologyKey: kubernetes.io/hostname
-    {{- if ne $root.Release.Service "Tiller" }}
-      serviceAccountName: "{{ $root.Values.serviceAccount.Name }}-{{ $root.Release.Name }}"
-    {{ end }}
-      initContainers:
-        - name: init-sysctl
-          image: busybox
-          command:
-          - /bin/sh
-          - -c
-          - |
-            sysctl -w vm.swappiness=0
-            sysctl -w kernel.core_pattern="/home/yugabyte/cores/core_%e.%p"
-          securityContext:
-            privileged: true
       containers:
       - name: "{{ .label }}"
         image: "{{ $root.Values.Image.repository }}:{{ $root.Values.Image.tag }}"
@@ -390,27 +376,4 @@ spec:
     matchLabels:
       app: {{ .label }}
 {{- end }}
-{{- end }}
-
-{{- if ne $root.Release.Service "Tiller" }}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ $root.Values.serviceAccount.Name }}-{{ $root.Release.Name }}
-  namespace: {{ $root.Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: {{ $root.Values.serviceAccount.Name }}
-  namespace: {{ $root.Release.Namespace }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: {{ $root.Values.serviceAccount.Name }}-{{ $root.Release.Name }}
-    namespace: {{ $root.Release.Namespace }}
 {{- end }}

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
   name: yugabyte-tls-client-cert
   namespace: "{{ $root.Release.Namespace }}"
   labels:
-    heritage: {{ $root.Release.Service | quote }}
+    heritage: {{ $root.Values.helm2Legacy | ternary "Tiller" ($root.Release.Service | quote) }}
     release: {{ $root.Release.Name | quote }}
     chart: "{{ $root.Chart.Name }}"
     component: "{{ $root.Values.Component }}"
@@ -34,7 +34,7 @@ metadata:
   namespace: "{{ $root.Release.Namespace }}"
   labels:
     app: "{{ $service.label }}"
-    heritage: {{ $root.Release.Service | quote }}
+    heritage: {{ $root.Values.helm2Legacy | ternary "Tiller" ($root.Release.Service | quote) }}
     release: {{ $root.Release.Name | quote }}
     chart: "{{ $root.Chart.Name }}"
     component: "{{ $root.Values.Component }}"
@@ -60,7 +60,7 @@ metadata:
   name: "{{ .name }}"
   labels:
     app: "{{ .label }}"
-    heritage: {{ $root.Release.Service | quote }}
+    heritage: {{ $root.Values.helm2Legacy | ternary "Tiller" ($root.Release.Service | quote) }}
     release: {{ $root.Release.Name | quote }}
     chart: "{{ $root.Chart.Name }}"
     component: "{{ $root.Values.Component }}"
@@ -86,7 +86,7 @@ metadata:
 {{ toYaml $endpoint.annotations | indent 4 }}
   labels:
     app: "{{ $endpoint.app }}"
-    heritage: {{ $root.Release.Service | quote }}
+    heritage: {{ $root.Values.helm2Legacy | ternary "Tiller" ($root.Release.Service | quote) }}
     release: {{ $root.Release.Name | quote }}
     chart: "{{ $root.Chart.Name }}"
     component: "{{ $root.Values.Component }}"
@@ -112,7 +112,7 @@ metadata:
   namespace: "{{ $root.Release.Namespace }}"
   labels:
     app: "{{ .label }}"
-    heritage: {{ $root.Release.Service | quote }}
+    heritage: {{ $root.Values.helm2Legacy | ternary "Tiller" ($root.Release.Service | quote) }}
     release: {{ $root.Release.Name | quote }}
     chart: "{{ $root.Chart.Name }}"
     component: "{{ $root.Values.Component }}"
@@ -133,7 +133,7 @@ spec:
         annotations:
           volume.beta.kubernetes.io/storage-class: {{ $storageInfo.storageClass }}
         labels:
-          heritage: {{ $root.Release.Service | quote }}
+          heritage: {{ $root.Values.helm2Legacy | ternary "Tiller" ($root.Release.Service | quote) }}
           release: {{ $root.Release.Name | quote }}
           chart: "{{ $root.Chart.Name }}"
           component: "{{ $root.Values.Component }}"
@@ -167,7 +167,7 @@ spec:
       {{ end }}
       labels:
         app: "{{ .label }}"
-        heritage: {{ $root.Release.Service | quote }}
+        heritage: {{ $root.Values.helm2Legacy | ternary "Tiller" ($root.Release.Service | quote) }}
         release: {{ $root.Release.Name | quote }}
         chart: "{{ $root.Chart.Name }}"
         component: "{{ $root.Values.Component }}"
@@ -401,9 +401,10 @@ metadata:
   namespace: {{ $root.Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ $root.Values.serviceAccount.Name }}
+  namespace: {{ $root.Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -102,7 +102,4 @@ tolerations: []
 
 affinity: {}
 
-serviceAccount:
-  Name: yugabyte-service-account
-
 helm2Legacy: false

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -104,3 +104,5 @@ affinity: {}
 
 serviceAccount:
   Name: yugabyte-service-account
+
+helm2Legacy: false

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -4,7 +4,7 @@
 Component: "yugabytedb"
 Image:
   repository: "yugabytedb/yugabyte"
-  tag: 2.1.4.0-b5
+  tag: 2.1.5.0-b17
   pullPolicy: IfNotPresent
 
 storage:

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -4,7 +4,7 @@
 Component: "yugabytedb"
 Image:
   repository: "yugabytedb/yugabyte"
-  tag: 2.1.2.0-b10
+  tag: 2.1.4.0-b5
   pullPolicy: IfNotPresent
 
 storage:

--- a/stable/yugaware/Chart.yaml
+++ b/stable/yugaware/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 2.1.4.0-b5
-version: 2.1.4
+appVersion: 2.1.5.0-b17
+version: 2.1.5
 home: https://www.yugabyte.com
 description: YugaWare is YugaByte Database's Orchestration and Management console.
 name: yugaware

--- a/stable/yugaware/Chart.yaml
+++ b/stable/yugaware/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 2.1.2.0-b10
-version: 2.1.2
+appVersion: 2.1.4.0-b5
+version: 2.1.4
 home: https://www.yugabyte.com
 description: YugaWare is YugaByte Database's Orchestration and Management console.
 name: yugaware

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: quay.io/yugabyte/yugaware
-  tag: 2.1.4.0-b5
+  tag: 2.1.5.0-b17
   pullPolicy: IfNotPresent
   pullSecret: yugabyte-k8s-pull-secret
 

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: quay.io/yugabyte/yugaware
-  tag: 2.1.2.0-b10
+  tag: 2.1.4.0-b5
   pullPolicy: IfNotPresent
   pullSecret: yugabyte-k8s-pull-secret
 


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds the ability to allow migrating of an existing helm chart from helm 2 to helm 3, following the suggestion mentioned here: https://github.com/helm/helm/issues/7211. If we set `helm2Legacy` to true, it changes the heritage to "Tiller", which can then be upgraded via helm3. More information about migrating charts from helm2 to helm3 can be found here: https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
This also removes the creation of a `service-account` and `ClusterRoleBinding`.
Also bumps the version to 2.1.5.0-b17.

#### Testing:
Tested by creating a helm2 deployment using:
```helm2 install yugabyte --name yb-test --namespace yb-test --wait```
Migrated the chart using `2to3` plugin for helm3:
```helm 2to3 convert yb-test```
Tested that the migrate worked using the following helm3 command:
```helm upgrade yb-test -n yb-test yugabyte --set Image.tag=2.1.4.0-b5,helm2Legacy=false --timeout 900s --wait```

#### Which issue this PR fixes: https://github.com/yugabyte/yugabyte-db/issues/4308

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
