### PR TITLE
[stable/yugabyte] Remove cluster IP field for loadbalancers services.

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -91,7 +91,6 @@ metadata:
     chart: "{{ $root.Chart.Name }}"
     component: "{{ $root.Values.Component }}"
 spec:
-  clusterIP:
   ports:
     {{- range $label, $port := $endpoint.ports }}
     - name: {{ $label | quote }}


### PR DESCRIPTION
Signed-off-by: Arnav Agarwal <14933889+Arnav15@users.noreply.github.com>

#### What this PR does / why we need it: Helm 3 doesn't play nice with an empty cluster IP field. This PR removes the clusterIP field.
Tested the chart works as expected with both helm 2 and helm 3 after the change.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
