### PR TITLE
[stable/yugabyte][stable/yugaware] Update YW chart to allow migration from helm2 to helm3

### DIFF
--- a/stable/yugabyte/Chart.yaml
+++ b/stable/yugabyte/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: yugabyte
-version: 2.1.5
-appVersion: 2.1.5.0-b17
+version: 2.1.6
+appVersion: 2.1.6.0-b17
 home: https://www.yugabyte.com
 description: YugabyteDB is the high-performance distributed SQL database for building global, internet-scale apps. 
 icon: https://avatars0.githubusercontent.com/u/17074854?s=200&v=4

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -91,7 +91,6 @@ metadata:
     chart: "{{ $root.Chart.Name }}"
     component: "{{ $root.Values.Component }}"
 spec:
-  clusterIP:
   ports:
     {{- range $label, $port := $endpoint.ports }}
     - name: {{ $label | quote }}

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -91,6 +91,9 @@ metadata:
     chart: "{{ $root.Chart.Name }}"
     component: "{{ $root.Values.Component }}"
 spec:
+  {{ if $endpoint.clusterIP }}
+  clusterIP: {{ $endpoint.clusterIP }}
+  {{- end }}
   ports:
     {{- range $label, $port := $endpoint.ports }}
     - name: {{ $label | quote }}

--- a/stable/yugaware/Chart.yaml
+++ b/stable/yugaware/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 2.1.5.0-b17
-version: 2.1.5
+appVersion: 2.1.6.0-b17
+version: 2.1.6
 home: https://www.yugabyte.com
 description: YugaWare is YugaByte Database's Orchestration and Management console.
 name: yugaware

--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "yugaware.name" . }}
     chart: {{ template "yugaware.chart" . }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    heritage: {{ .Values.helm2Legacy | ternary "Tiller" (.Release.Service | quote) }}
 data:
   postgres_user: "postgres"
   postgres_password: "{{ b64enc (randAlphaNum 8) }}"
@@ -24,7 +24,7 @@ metadata:
     app: {{ template "yugaware.name" . }}
     chart: {{ template "yugaware.chart" . }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    heritage: {{ .Values.helm2Legacy | ternary "Tiller" (.Release.Service | quote) }}
 data:
   application.docker.conf: |
     play.crypto.secret=${APP_SECRET}
@@ -95,7 +95,7 @@ metadata:
     app: {{ template "yugaware.name" . }}
     chart: {{ template "yugaware.chart" . }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    heritage: {{ .Values.helm2Legacy | ternary "Tiller" (.Release.Service | quote) }}
 data:
   default.conf: |
     server {
@@ -147,7 +147,7 @@ metadata:
     app: {{ template "yugaware.name" . }}
     chart: {{ template "yugaware.chart" . }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    heritage: {{ .Values.helm2Legacy | ternary "Tiller" (.Release.Service | quote) }}
 data:
   prometheus.yml: |
     global:

--- a/stable/yugaware/templates/service.yaml
+++ b/stable/yugaware/templates/service.yaml
@@ -10,13 +10,15 @@ metadata:
     app: {{ .Release.Name }}-yugaware
     chart: {{ template "yugaware.chart" . }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    heritage: {{ .Values.helm2Legacy | ternary "Tiller" (.Release.Service | quote) }}
     {{- if .Values.yugaware.service.annotations }}
     annotations:
 {{ toYaml .Values.yugaware.service.annotations | indent 6 }}
     {{- end }}
 spec:
-  clusterIP:
+{{- if .Values.yugaware.service.clusterIP }}
+  clusterIP: {{ .Values.yugaware.service.clusterIP }}
+{{- end }}
   ports:
   - name: ui
 {{- if .Values.tls.enabled }}
@@ -42,7 +44,7 @@ metadata:
     app: {{ .Release.Name }}-yugaware
     chart: {{ template "yugaware.chart" . }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    heritage: {{ .Values.helm2Legacy | ternary "Tiller" (.Release.Service | quote) }}
 spec:
   serviceName: {{ .Release.Name }}-yugaware
   replicas: {{ .Values.yugaware.replicas }}

--- a/stable/yugaware/templates/volumes.yaml
+++ b/stable/yugaware/templates/volumes.yaml
@@ -7,7 +7,7 @@ metadata:
     app: {{ template "yugaware.name" . }}
     chart: {{ template "yugaware.chart" . }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    heritage: {{ .Values.helm2Legacy | ternary "Tiller" (.Release.Service | quote) }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: quay.io/yugabyte/yugaware
-  tag: 2.1.5.0-b17
+  tag: 2.1.6.0-b17
   pullPolicy: IfNotPresent
   pullSecret: yugabyte-k8s-pull-secret
 

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -35,3 +35,5 @@ helm:
   package: "/opt/yugabyte/helm/yugabyte-latest.tgz"
 
 domainName: "cluster.local"
+
+helm2Legacy: false


### PR DESCRIPTION

#### What this PR does / why we need it:
Makes the necessary changes to migrate YW from helm2 to helm3. Also adds compatibility in Yugabyte for being able to use a customizable clusterIP since helm3 doesn't work well with charts deployed with an empty clusterIP [https://github.com/helm/helm/issues/6378].
Migration instructions: https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
For YW upgrades from a migrated chart:
Just set the clusterIP value in `yugaware.services.clusterIP` and set `helm2Legacy` to true.
For YB upgrades from a migrated chart:
Set the clusterIP value for each `serviceEndpoints` as `clusterIP` and set `helm2Legacy` to true.
Running an upgrade from a helm3 deployment from an older chart will also need the `clusterIP` field to be set

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[stable/chart]`)
